### PR TITLE
Update API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -383,7 +383,8 @@ policy_read_only = {"Version":"2012-10-17",
                     ]}
 
 
-minioClient.set_bucket_policy('mybucket', policy_read_only)
+minioClient.set_bucket_policy('mybucket', json.dumps(policy_read_only)//set_bucket_policy
+)
 ```
 
 <a name="get_bucket_notification"></a>


### PR DESCRIPTION
The call to set_bucket_policy only takes a str. The call in use is sending the object. Other places in minio repository show using json.dumps to make the string.